### PR TITLE
Add Force GPU toggle and explicit device selection for Whisper

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -32,11 +32,11 @@ class Settings:
                 return default
         elif key == 'language' and value not in self.VALID_LANGUAGES:
             return 'en'
-        elif key == 'auto_detect':
+        elif key in ('auto_detect', 'force_gpu'):
             if isinstance(value, bool):
                 return value
             return str(value).lower() in ('true', '1', 'yes')
-                
+
         return value
         
     def set(self, key, value):
@@ -49,7 +49,7 @@ class Settings:
                 raise ValueError(f"Invalid mic_index: {value}")
         elif key == 'language' and value not in self.VALID_LANGUAGES:
             raise ValueError(f"Invalid language: {value}")
-        elif key == 'auto_detect':
+        elif key in ('auto_detect', 'force_gpu'):
             value = bool(value)
                 
         self.settings.setValue(key, value)

--- a/settings_window.py
+++ b/settings_window.py
@@ -87,7 +87,21 @@ class SettingsWindow(QWidget):
         self.lang_combo.setEnabled(not auto_detect)
         self.lang_combo.currentIndexChanged.connect(self.on_language_changed)
         model_layout.addRow("Language:", self.lang_combo)
-        
+
+        # GPU / device selection
+        self.force_gpu_cb = QCheckBox("Force GPU (CUDA) acceleration")
+        force_gpu = self.settings.get('force_gpu', False)
+        self.force_gpu_cb.setChecked(force_gpu)
+        self.force_gpu_cb.toggled.connect(self.on_force_gpu_changed)
+        model_layout.addRow(self.force_gpu_cb)
+
+        # Live device status label, refreshed whenever the setting changes
+        # or a model load finishes.
+        self.device_status_label = QLabel()
+        self.device_status_label.setStyleSheet("color: #666;")
+        self._refresh_device_status()
+        model_layout.addRow("Active device:", self.device_status_label)
+
         model_group.setLayout(model_layout)
         layout.addWidget(model_group)
         
@@ -176,6 +190,32 @@ class SettingsWindow(QWidget):
         except ValueError as e:
             logger.error(f"Failed to set auto_detect: {e}")
 
+    def on_force_gpu_changed(self, checked):
+        try:
+            self.settings.set('force_gpu', checked)
+        except ValueError as e:
+            logger.error(f"Failed to set force_gpu: {e}")
+        self._refresh_device_status()
+
+    def _refresh_device_status(self):
+        """Show the device that will actually be used given the current
+        force_gpu setting and the detected hardware."""
+        from transcriber import resolve_device
+        force_gpu = self.settings.get('force_gpu', False)
+        device, fp16 = resolve_device(force_gpu=force_gpu)
+        if device == "cuda":
+            try:
+                import torch
+                gpu_name = torch.cuda.get_device_name(0)
+            except Exception:
+                gpu_name = "CUDA GPU"
+            text = f"GPU: {gpu_name} (fp16)"
+        else:
+            text = "CPU (fp32)"
+            if force_gpu:
+                text += " - GPU not available"
+        self.device_status_label.setText(text)
+
     def on_language_changed(self, index):
         language_code = self.lang_combo.currentData()
         try:
@@ -213,11 +253,17 @@ class SettingsWindow(QWidget):
     def load_model(self, model_name):
         try:
             import whisper
-            self.whisper_model = whisper.load_model(model_name)
+            from transcriber import resolve_device
+            force_gpu = self.settings.get('force_gpu', False)
+            device, fp16 = resolve_device(force_gpu=force_gpu)
+            self.whisper_model = whisper.load_model(model_name, device=device)
             self.current_model = model_name
-            self.progress_label.setText(f"Model {model_name} loaded successfully")
+            self.progress_label.setText(
+                f"Model {model_name} loaded on {device.upper()}"
+            )
             self.progress_bar.setRange(0, 100)
             self.progress_bar.setValue(100)
+            self._refresh_device_status()
             self.initialization_complete.emit()
         except Exception as e:
             logger.exception("Failed to load whisper model")

--- a/transcriber.py
+++ b/transcriber.py
@@ -6,28 +6,67 @@ import time
 from settings import Settings
 logger = logging.getLogger(__name__)
 
+
+def cuda_is_available():
+    """Check whether a usable CUDA GPU is present.
+
+    Imported lazily so the app still runs if torch is replaced by a
+    CPU-only build. Returns True only when torch can actually initialize
+    a CUDA context.
+    """
+    try:
+        import torch
+        return bool(torch.cuda.is_available())
+    except Exception as e:
+        logger.warning(f"CUDA availability check failed: {e}")
+        return False
+
+
+def resolve_device(force_gpu=False):
+    """Resolve the torch device Whisper should run on.
+
+    Preference order:
+      1. cuda when force_gpu is enabled AND a GPU is reachable
+      2. cuda when auto-detected (Whisper's historical behavior)
+      3. cpu as the final fallback
+
+    Returns a (device, fp16) tuple. fp16 is only safe on CUDA; running
+    fp16 on CPU throws, so it is forced to False on cpu.
+    """
+    cuda_ok = cuda_is_available()
+    if force_gpu and not cuda_ok:
+        logger.warning(
+            "Force GPU is enabled but no CUDA device is available; "
+            "falling back to CPU."
+        )
+    if cuda_ok:
+        return "cuda", True
+    return "cpu", False
+
+
 class TranscriptionWorker(QThread):
     finished = pyqtSignal(str, str)
     progress = pyqtSignal(str)
     error = pyqtSignal(str)
-    
-    def __init__(self, model, audio_file, language=None):
+
+    def __init__(self, model, audio_file, language=None, fp16=False):
         super().__init__()
         self.model = model
         self.audio_file = audio_file
         self.language = language
-        
+        self.fp16 = fp16
+
     def run(self):
         try:
             if not os.path.exists(self.audio_file):
                 raise FileNotFoundError(f"Audio file not found: {self.audio_file}")
-                
+
             self.progress.emit("Loading audio file...")
-            
+
             self.progress.emit("Processing audio with Whisper...")
             result = self.model.transcribe(
                 self.audio_file,
-                fp16=False,
+                fp16=self.fp16,
                 language=self.language
             )
             
@@ -60,24 +99,34 @@ class WhisperTranscriber(QObject):
         super().__init__()
         self.model = None
         self.worker = None
+        self.device = "cpu"
+        self.fp16 = False
         self._cleanup_timer = QTimer()
         self._cleanup_timer.timeout.connect(self._cleanup_worker)
         self._cleanup_timer.setSingleShot(True)
         self.load_model()
-        
+
     def load_model(self):
         try:
             settings = Settings()
             model_name = settings.get('model', 'tiny')
-            logger.info(f"Loading Whisper model: {model_name}")
-            
+            force_gpu = settings.get('force_gpu', False)
+
+            self.device, self.fp16 = resolve_device(force_gpu=force_gpu)
+            logger.info(
+                f"Loading Whisper model: {model_name} on {self.device.upper()} "
+                f"(force_gpu={force_gpu}, fp16={self.fp16})"
+            )
+
             # Redirect whisper's logging to our logger
             import logging as whisper_logging
             whisper_logging.getLogger("whisper").setLevel(logging.WARNING)
-            
-            self.model = whisper.load_model(model_name)
-            logger.info("Model loaded successfully")
-            
+
+            self.model = whisper.load_model(model_name, device=self.device)
+            logger.info(
+                f"Model loaded successfully on {self.device.upper()}"
+            )
+
         except Exception as e:
             logger.error(f"Failed to load Whisper model: {e}")
             raise
@@ -99,7 +148,9 @@ class WhisperTranscriber(QObject):
             
         self.transcription_progress.emit("Starting transcription...")
             
-        self.worker = TranscriptionWorker(self.model, audio_file, language=language)
+        self.worker = TranscriptionWorker(
+            self.model, audio_file, language=language, fp16=self.fp16
+        )
         self.worker.finished.connect(self.transcription_finished)
         self.worker.progress.connect(self.transcription_progress)
         self.worker.error.connect(self.transcription_error)


### PR DESCRIPTION
## Problem
Whisper's device was chosen implicitly: `load_model()` was called with no `device` argument, so Whisper internally ran `cuda if torch.cuda.is_available() else cpu` at load time. That check is a lazy CUDA init and is unreliable across processes (CPU-only torch wheels, driver/runtime mismatch, first-import races), so the app would sometimes fall back to the slow CPU path with no user control.

This was compounded by `fp16=False` being hardcoded in the transcription worker — the CPU code path. Even on a CUDA GPU the model ran in fp32 (~2x slower), making GPU mode feel barely faster than CPU. The two model-load sites (transcriber and settings window) also auto-detected independently and could disagree.

## Fix
- Centralize device selection in `resolve_device()` so the device is chosen explicitly, and tie `fp16` to it (True on CUDA, False on CPU — fp16 throws on CPU).
- Add a `force_gpu` setting plus a "Force GPU (CUDA) acceleration" checkbox in Settings, so the user can guarantee GPU use.
- Show the resolved device (with GPU name) as a live status label, so the choice is observable.
- Route both model-load sites (transcriber + settings window) through the same logic.

Relates to #12 (a focused take on the GPU-detection concern, without the broader refactor in that PR).